### PR TITLE
Use formgrader_hubapi_token to pre-load tokens

### DIFF
--- a/host_vars/hostname.example
+++ b/host_vars/hostname.example
@@ -22,7 +22,7 @@ jupyterhub_users:
   - student2
 
 # The secret token to use for accessing the proxy
-# Creat using something like `openssl rand -hex 32`
+# Create using something like `openssl rand -hex 32`
 proxy_auth_token: ''
 
 # nbgrader formgrade setup
@@ -33,6 +33,11 @@ nbgrader_graders:
     - instructor
     - grader
 nbgrader_port: 5005
+
+# The API token formgrader will use to make requests of the Hub
+# Create using something like `openssl rand -hex 32`
+formgrader_hubapi_token: ''
+
 
 # ---------------------------------------------------
 # Optional

--- a/roles/formgrade/tasks/main.yml
+++ b/roles/formgrade/tasks/main.yml
@@ -17,10 +17,6 @@
     - autograded
     - submitted
 
-- name: generate a config proxy auth token for the formgrade instance
-  command: jupyterhub token --db={{ jupyterhub_srv_dir }}/jupyterhub.sqlite {{nbgrader_owner}}
-  register: hubapi_token
-
 - name: install nbgrader config file
   template: "src=nbgrader_config.py.j2 dest={{nbgrader_base_dir}}/nbgrader_config.py owner={{nbgrader_owner}} mode=700"
   become: true

--- a/roles/formgrade/templates/nbgrader_config.py.j2
+++ b/roles/formgrade/templates/nbgrader_config.py.j2
@@ -8,7 +8,7 @@ c.FormgradeApp.authenticator_class = u'nbgrader.auth.hubauth.HubAuth'
 c.FormgradeApp.port = {{nbgrader_port}}
 
 c.HubAuth.proxy_token = u'{{proxy_auth_token}}'
-c.HubAuth.hubapi_token = u'{{hubapi_token.stdout}}'
+c.HubAuth.hubapi_token = u'{{formgrader_hubapi_token}}'
 c.HubAuth.hub_base_url = u'https://{{ansible_fqdn}}'
 c.HubAuth.notebook_url_prefix = u'{{nbgrader_base_dir}}'
 c.HubAuth.graders = [

--- a/roles/jupyterhub/tasks/packages.yml
+++ b/roles/jupyterhub/tasks/packages.yml
@@ -9,5 +9,5 @@
   pip: name={{item}} state=present executable=pip3 editable=false
   become: true
   with_items:
-    - git+https://github.com/jupyter/jupyterhub#egg=jupyterhub
-    - git+https://github.com/jupyter/oauthenticator#egg=oauthenticator
+    - jupyterhub==0.6
+    - oauthenticator==0.3

--- a/roles/jupyterhub/templates/jupyterhub_config.py.j2
+++ b/roles/jupyterhub/templates/jupyterhub_config.py.j2
@@ -38,5 +38,8 @@ c.Authenticator.whitelist = {
 c.Authenticator.whitelist = set()
 {% endif %}
 
-
-
+{% if formgrader_hubapi_token %}
+c.JupyterHub.api_tokens = {
+    '{{formgrader_hubapi_token}}': '{{nbgrader_owner}}',
+}
+{% endif %}


### PR DESCRIPTION
requires JupyterHub 0.6 for preloaded tokens.

Pins JupyterHub, OAuthenticator to releases instead of git master.
