### PR TITLE
Use inventory hostname instead of ansible_fqdn

### DIFF
--- a/group_vars/jupyterhub_hosts
+++ b/group_vars/jupyterhub_hosts
@@ -36,8 +36,8 @@ ssl_key_path: "{{ssl_path}}/ssl.key"
 ssl_cert_path: "{{ssl_path}}/ssl.crt"
 
 # If letsencrypt is used to get SSL cert
-letsencrypt_ssl_key_path: "/etc/letsencrypt/live/{{ansible_fqdn}}/privkey.pem"
-letsencrypt_ssl_cert_path: "/etc/letsencrypt/live/{{ansible_fqdn}}/fullchain.pem"
+letsencrypt_ssl_key_path: "/etc/letsencrypt/live/{{inventory_hostname}}/privkey.pem"
+letsencrypt_ssl_cert_path: "/etc/letsencrypt/live/{{inventory_hostname}}/fullchain.pem"
 
 # ---------------------------------------------------
 # Nbgrader config

--- a/roles/formgrade/templates/nbgrader_config.py.j2
+++ b/roles/formgrade/templates/nbgrader_config.py.j2
@@ -9,7 +9,7 @@ c.FormgradeApp.port = {{nbgrader_port}}
 
 c.HubAuth.proxy_token = u'{{proxy_auth_token}}'
 c.HubAuth.hubapi_token = u'{{formgrader_hubapi_token}}'
-c.HubAuth.hub_base_url = u'https://{{ansible_fqdn}}'
+c.HubAuth.hub_base_url = u'https://{{inventory_hostname}}'
 c.HubAuth.notebook_url_prefix = u'{{nbgrader_base_dir}}'
 c.HubAuth.graders = [
 {%- for grader in nbgrader_graders[:-1] -%}

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -22,7 +22,7 @@
   when: use_letsencrypt
 
 - name: run letsencrypt to generate SSL certs
-  command: ./letsencrypt-auto certonly --agree-tos -m {{letsencrypt_email}} -d {{inventory_hostname}}
+  command: ./letsencrypt-auto certonly --standalone --agree-tos -m {{letsencrypt_email}} -d {{inventory_hostname}}
   args:
     chdir: /tmp/letsencrypt
     creates: /etc/letsencrypt/live/{{inventory_hostname}}/

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -54,10 +54,6 @@
 # Configure and launch nginx
 # ---------------------------------------------------
 
-- name: start the nginx service
-  service: name=nginx state=started enabled=yes
-  become: true
-
 - name: find notebook static directory
   command: python3 -c 'import notebook; import os; print(os.path.join(notebook.__path__[0], "static"));'
   register: notebook_static_directory
@@ -67,3 +63,8 @@
   become: true
   notify:
     - reload nginx
+
+- name: start the nginx service
+  service: name=nginx state=started enabled=yes
+  become: true
+

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -22,10 +22,10 @@
   when: use_letsencrypt
 
 - name: run letsencrypt to generate SSL certs
-  command: ./letsencrypt-auto certonly --agree-tos -m {{letsencrypt_email}} -d {{ansible_fqdn}}
+  command: ./letsencrypt-auto certonly --agree-tos -m {{letsencrypt_email}} -d {{inventory_hostname}}
   args:
     chdir: /tmp/letsencrypt
-    creates: /etc/letsencrypt/live/{{ansible_fqdn}}/
+    creates: /etc/letsencrypt/live/{{inventory_hostname}}/
   become: true
   when: use_letsencrypt
 


### PR DESCRIPTION
inventory hostname is user-specified, whereas ansible_fqdn is discovered on the system and can be unrealiable.

There are a couple of other fixes for nginx found during this:
- missing `--standalone` arg for letsencrypt caused a hang
- start nginx after configuring it, or it will balk on first run
