### PR TITLE
add conda to PATH in two places

### DIFF
--- a/roles/python/tasks/conda.yml
+++ b/roles/python/tasks/conda.yml
@@ -19,6 +19,7 @@
     creates: "{{ conda_prefix }}"
     executable: /bin/bash
 
+# add conda to path in two places, so it's always registered
 - name: add conda to PATH
   # add it to the front of bashrc, so it's even on noninteractive paths
   lineinfile:
@@ -26,6 +27,12 @@
     state: present
     line: "export PATH={{conda_prefix}}/bin:$PATH"
     insertbefore: BOF
+
+- name: add conda to login PATH
+  # add it to profile, so it's for all login shells
+  copy:
+    dest: /etc/profile.d/conda.sh
+    content: "export PATH={{conda_prefix}}/bin:$PATH"
 
 - name: add conda config
   copy:


### PR DESCRIPTION
- profile, so login shells get it
- bashrc, so non-login shells get it

I can't see a way do to this in a single place that _always_ has an effect, so be a little redundant.

closes #13
