### PR TITLE
updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To *deploy* this JupyterHub reference deployment, you should have:
 - A formatted and mounted directory to store user home directories
 - A valid DNS name
 - SSL certificate
-- Ansible 2.0+ installed for JupyterHub configuration (`pip install ansible>=2.0`)
+- Ansible 2.1+ installed for JupyterHub configuration (`pip install "ansible>=2.1"`)
 
 For *administration* of the server, you should also:
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-remote_user=ubuntu
+remote_user=root
 hostfile=./hosts
 library = ./ansible-conda
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,4 +9,4 @@ become_method=sudo
 become_user=root
 
 [ssh_connection]
-ssh_args = -o ServerAliveInterval=60
+ssh_args = -o ServerAliveInterval=60 -o ControlMaster=auto -o ControlPersist=10m

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,18 +1,14 @@
 ---
 
-# Make sure Python 2.7 is installed
 - hosts: jupyterhub_hosts
-  gather_facts: False
   tasks:
-    - name: apt-get update
-      raw: apt-get update -qq
-    - name: Install python 2.7
-      raw: apt-get install -qq python2.7
+    - assert:
+        that: (ansible_version.major, ansible_version.minor) >= (2, 1)
+        msg: require ansible >= 2.1, found {{ansible_version.full}}
 
-- hosts: jupyterhub_hosts
-  tasks:
     - command: echo "$PATH"
       register: default_path
+
 
 - hosts: jupyterhub_hosts
   roles:

--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -1,11 +1,16 @@
 ---
 
-- name: apt upgrade
-  apt: upgrade=safe update_cache=yes cache_valid_time=3600
+- name: apt update
+  apt: update_cache=yes cache_valid_time=3600
   become: yes
 
 - name: install aptitude
   apt: pkg=aptitude
+  become: yes
+
+# upgrade requires aptitude
+- name: apt upgrade
+  apt: upgrade=safe
   become: yes
 
 - name: build-essential

--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -1,19 +1,15 @@
 ---
 
-- name: update the apt index
-  apt: update_cache=yes cache_valid_time=3600
+- name: apt upgrade
+  apt: upgrade=safe update_cache=yes cache_valid_time=3600
   become: yes
 
 - name: install aptitude
   apt: pkg=aptitude
   become: yes
 
-- name: Upgrade all packages
-  apt: upgrade=safe
-  become: yes
-
 - name: build-essential
-  apt: pkg=build-essential state=present update_cache=yes cache_valid_time=3600
+  apt: pkg=build-essential state=present
   become: true
 
 - name: other developer tools
@@ -33,5 +29,5 @@
     - htop
 
 - name: install open-iscsi for cloud block volumes
-  apt: pkg=open-iscsi state=present update_cache=yes cache_valid_time=3600
+  apt: pkg=open-iscsi state=present
   become: true

--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -5,7 +5,7 @@
 
 - name: fetch public keys from github
   get_url: dest=/tmp/pubkeys/{{ item }}-pubkeys url=https://github.com/{{ item }}.keys force=yes
-  with_items: github_usernames
+  with_items: '{{github_usernames}}'
   when: github_usernames is defined and github_usernames != []
 
 - name: assemble the authorized keys file

--- a/roles/nginx/files/letsencrypt-renew
+++ b/roles/nginx/files/letsencrypt-renew
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+date >> /var/log/letsencrypt.log
+certbot-auto renew --no-self-upgrade 2>&1 &>> /var/log/letsencrypt.log
+docker kill -s HUP nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -32,12 +32,6 @@
     mode: 755
   when: use_letsencrypt
 
-- name: skip pycparser wheel (letsencrypt workaround)
-  # workaround https://community.letsencrypt.org/t/certbot-auto-fails-while-setting-up-virtual-environment-complains-about-package-hashes/20529
-  command: sed -i "s@pycparser==2.14\ \\\@pycparser==2.14 --no-binary pycparser\\\@" /usr/local/bin/certbot-auto
-  become: true
-  when: use_letsencrypt
-
 - name: SSL credentials with certbot
   command: /usr/local/bin/certbot-auto certonly --agree-tos --standalone -m {{ letsencrypt_email }} -d {{ inventory_hostname }} creates={{ letsencrypt_ssl_cert_path }}
   become: true

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -16,21 +16,37 @@
   become: true
   when: use_letsencrypt
 
-- stat: path=/etc/letsencrypt/live/{{inventory_hostname}}/cert.pem
-  register: letsencrypt_cert
-
-- name: clone or update the latest letsencrypt repo
-  git: repo=https://github.com/letsencrypt/letsencrypt.git dest=/tmp/letsencrypt force=yes
+- name: set apt-yes default (needed for certbot)
+  lineinfile:
+    dest: /etc/apt/apt.conf.d/99-apt-yes
+    state: present
+    line: 'APT::Get::Assume-Yes "true";'
+    create: yes
   become: true
-  when: use_letsencrypt and letsencrypt_cert.stat.exists == False
+  when: use_letsencrypt
 
-- name: run letsencrypt to generate SSL certs
-  command: ./letsencrypt-auto certonly --standalone --agree-tos -m {{letsencrypt_email}} -d {{inventory_hostname}}
-  args:
-    chdir: /tmp/letsencrypt
-    creates: /etc/letsencrypt/live/{{inventory_hostname}}/
+- name: install certbot (letsencrypt)
+  get_url:
+    url: https://dl.eff.org/certbot-auto
+    dest: /usr/local/bin/certbot-auto
+    mode: 755
+  when: use_letsencrypt
+
+- name: skip pycparser wheel (letsencrypt workaround)
+  # workaround https://community.letsencrypt.org/t/certbot-auto-fails-while-setting-up-virtual-environment-complains-about-package-hashes/20529
+  command: sed -i "s@pycparser==2.14\ \\\@pycparser==2.14 --no-binary pycparser\\\@" /usr/local/bin/certbot-auto
   become: true
-  when: use_letsencrypt and letsencrypt_cert.stat.exists == False
+  when: use_letsencrypt
+
+- name: SSL credentials with certbot
+  command: /usr/local/bin/certbot-auto certonly --agree-tos --standalone -m {{ letsencrypt_email }} -d {{ inventory_hostname }} creates={{ letsencrypt_ssl_cert_path }}
+  become: true
+  when: use_letsencrypt
+
+- name: Setup letsencrypt renewal with cron
+  copy: src=letsencrypt-renew dest=/etc/cron.daily/letsencrypt-renew mode=0755
+  become: true
+  when: use_letsencrypt
 
 # ---------------------------------------------------
 # Or, install existing SSL cert/key

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -30,9 +30,14 @@ http {
 
 
         ssl on;
-{% if use_letsencrypt %}		
+{% if use_letsencrypt %}
         ssl_certificate {{ letsencrypt_ssl_cert_path }};
         ssl_certificate_key {{ letsencrypt_ssl_key_path }};
+
+        # letsencrypt renewal authorization area
+        location /.well-known/ {
+            alias /etc/letsencrypt/webroot/.well-known/;
+        }
 {% else %}
         ssl_certificate {{ ssl_cert_path }};
         ssl_certificate_key {{ ssl_key_path }};

--- a/roles/python/tasks/jupyter.yml
+++ b/roles/python/tasks/jupyter.yml
@@ -5,12 +5,12 @@
   conda: name={{item}} state=present
   become: true
   with_items:
-    - notebook==4.2
+    - notebook=4.2
     - ipyparallel
     - ipykernel
     - nbconvert
     - pandoc
-    - ipywidgets==5
+    - ipywidgets=5
 
 - name: install python3 kernelspec
   command: python3 -m IPython kernel install

--- a/roles/python/tasks/jupyter.yml
+++ b/roles/python/tasks/jupyter.yml
@@ -10,11 +10,6 @@
     - ipykernel
     - nbconvert
     - pandoc
-
-- name: pip install non-conda deps
-  pip: name={{item}} state=present
-  become: true
-  with_items:
     - ipywidgets==5
 
 - name: install python3 kernelspec

--- a/roles/python/tasks/python3.yml
+++ b/roles/python/tasks/python3.yml
@@ -3,9 +3,9 @@
 - name: user conda packages
   conda: name={{item}} state=present
   become: true
-  with_items: conda_packages
+  with_items: '{{conda_packages}}'
 
 - name: user pip packages
   pip: name={{item}} state=present
   become: true
-  with_items: pip_packages
+  with_items: '{{pip_packages}}'

--- a/roles/python/vars/main.yml
+++ b/roles/python/vars/main.yml
@@ -1,7 +1,7 @@
-miniconda_version: 4.0.5
+miniconda_version: 4.1.11
 conda_installer: Miniconda3-{{miniconda_version}}-Linux-x86_64.sh
 conda_prefix: /opt/conda
-conda_checksum: "sha256:a7bcd0425d8b6688753946b59681572f63c2241aed77bf0ec6de4c5edc5ceeac"
+conda_checksum: "md5:874dbb0d3c7ec665adf7231bbb575ab2"
 conda_config:
   channels:
     - conda-forge


### PR DESCRIPTION
- set default user back to root in ansible.cfg (this can be overridden in vars, but root should be left as the default)
- bump miniconda to 4.1.11
- install a few more things with conda instead of pip, now that we are using conda-forge
- minor apt tweaks
- use certbot-auto tool for letsencrypt
- autorenew letsencrypt certs with cron

I did have to include a workaround for letsencrypt due to a problem in the pycparser wheel, but that should be short-lived (https://github.com/certbot/certbot/pull/3575)

With this PR, I was able to run a deployment start to finish with a fresh Ubuntu 14.04 machine on Rackspace without errors.

closes #25
closes #26
closes #27

cc @ellisonbg

I wasn't able to reproduce the errors you saw in #26, #27. What options did you specify, and what exact version of this repo were you using? Did you use letsencrypt or your own SSL certs?

What do you see for `conda config --get` and `conda config get --system`?
