### PR TITLE
Switch to requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx>=1.4.6
+sphinx_rtd_theme
+recommonmark
+pyenchant
+sphinxcontrib-spelling

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,3 @@
-conda:
-    file: docs/environment.yml
+requirements_file: docs/requirements.txt
 python:
     version: 3


### PR DESCRIPTION
@minrk I would like to go ahead and swap this docs build to use `requirements.txt` instead of conda. The last PR broke the build on RTD. I did a bunch of troubleshooting yesterday re: conda and rtd, and I ran into a ton of build errors, timeouts, etc. Switching to `requirements.txt`, it all built fine and much faster. 
