### PR TITLE
Activate Ansible logging

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 remote_user=root
 hostfile=./hosts
 library = ./ansible-conda
+log_path = ./ansible.log
 
 [privilege_escalation]
 become=True


### PR DESCRIPTION
Ansible by default does not log the action it performs. I think it is useful to activate it so that users can debug any error more easily.

I find myself in this situation yesterday: I was installing this on a Ubuntu server (not a VM) and for some reason `configurable-http-proxy` failed to install, it was an easy fix doing it manually but I did not understand what went wrong because I didn't have the log, didn't want to mess with `syslog`.