### PR TITLE
Nbgrader refactor

### DIFF
--- a/deploy_formgrade.yml
+++ b/deploy_formgrade.yml
@@ -3,6 +3,21 @@
 # This playbook is deployed separately and after `deploy.yml` since the
 # instructor's user account must be set up before deploying formgrader
 
+# Multiple formgrade instances can be run on a system, one for each course
+ 
 - hosts: jupyterhub_hosts
   roles:
-    - formgrade
+    - {
+        role: formgrade,
+        nbgrader_course_id: "course1",
+        nbgrader_owner: "instructor1",
+        nbgrader_graders: ["instructor1", "grader1"],
+        nbgrader_port: 5005
+      }
+    - {
+        role: formgrade,
+        nbgrader_course_id: "course2",
+        nbgrader_owner: "instructor2",
+        nbgrader_graders: ["instructor2", "grader2"],
+        nbgrader_port: 5006
+      }

--- a/docs/source/configure-nbgrader.rst
+++ b/docs/source/configure-nbgrader.rst
@@ -6,25 +6,28 @@ The nbgrader package will be installed with the reference deployment.
 To run nbgrader's formgrade application or use its notebook
 extensions, additional steps are needed.
 
-Configuring the extension
--------------------------
-Each user who wants to use the notebook extension will need to run::
-
-    $ nbgrader extension activate
-
 Deploy formgrade
 ----------------
-Log into JupyterHub as the main instructor (`nbgrader_owner`).
 
-Run the ansible-playbook to deploy formgrade::
+First, edit the :file:`deploy_formgrade.yml` file with the information
+for each course you want to start formgrade for. Each course should have a 
+unique `nbgrader_course_id` and `nbgrader_port`.
+
+Second, make sure that each main instructor (the `nbgrader_owner` for each
+course) has logged into JuptyerHub at least once. This ensures that their
+home directory has been created. The home directory of the main instructor
+is used for the main nbgrader course files. It is assumed that the main
+instructor will be running the nbgrader command line programs.
+
+Third, run the ansible-playbook to deploy formgrade::
 
 	$ ansible-playbook deploy_formgrade.yml
 
-SSH into the server::
+Fourth, SSH into the JupyterHub server::
 
     $ ssh {user}@{hostname}
 
-Restart jupyterhub and nbgrader by doing::
+Finally, restart jupyterhub and nbgrader by doing::
 
     $ supervisorctl reload
 

--- a/group_vars/jupyterhub_hosts
+++ b/group_vars/jupyterhub_hosts
@@ -45,3 +45,4 @@ letsencrypt_ssl_cert_path: "/etc/letsencrypt/live/{{inventory_hostname}}/fullcha
 
 nbgrader_log_dir: /var/log/nbgrader
 nbgrader_exchange_dir: /srv/nbgrader/exchange
+nbgrader_base_dir: "{{home_dir}}/{{nbgrader_owner}}/nbgrader/{{nbgrader_course_id}}"

--- a/host_vars/hostname.example
+++ b/host_vars/hostname.example
@@ -34,16 +34,6 @@ install_bash_kernel: true
 # enter between quotation marks below
 proxy_auth_token: ''
 
-# nbgrader and formgrade settings (use_nbgrader default: false)
-use_nbgrader: false
-nbgrader_course_id: mycourse
-nbgrader_owner: instructor
-nbgrader_base_dir: "{{home_dir}}/{{nbgrader_owner}}/nbgrader/{{nbgrader_course_id}}"
-nbgrader_graders:
-    - instructor
-    - grader
-nbgrader_port: 5005
-
 # The API token formgrader will use to make Hub requests
 # Create using something like `openssl rand -hex 32` and
 # enter between quotation marks below

--- a/roles/nbgrader/tasks/main.yml
+++ b/roles/nbgrader/tasks/main.yml
@@ -21,6 +21,13 @@
     - directory
     - touch
 
-- name: install the nbgrader extension
-  command: nbgrader extension install
+- name: install the nbgrader nbextensions
+  command: jupyter nbextension {{item}} --sys-prefix --py nbgrader
+  become: true
+  with_items:
+    - install
+    - enable
+
+- name: install the nbgrader serverextension
+  command: jupyter serverextension enable --sys-prefix --py nbgrader
   become: true


### PR DESCRIPTION
Here is a PR that refactors the ansible stuff for nbgrader:

* Uses nbgrader's new approach to installing nbextension's and serverextension (just use the regular jupyter commands).
* Allows for multiple formgrade instances.

I still need to test this on my deployment before we merge...