### PR TITLE
Moving package lists to main host vars.

### DIFF
--- a/host_vars/hostname.example
+++ b/host_vars/hostname.example
@@ -54,6 +54,107 @@ formgrader_hubapi_token: ''
 ansible_python_interpreter: '/usr/bin/python2.7'
 
 # ---------------------------------------------------
+# Packages
+# ---------------------------------------------------
+
+# Add or remove packages here for different package
+# managers here (conda, pip, cran). The package listed
+# here are on-top of the base installation of jupyter,
+# ipython and the IPython and IR kernel.
+
+conda_packages:
+  - numpy
+  - scipy
+  - matplotlib
+  - cython
+  - h5py
+  - scikit-learn
+  - scikit-image
+  - pandas
+  - sympy
+  - pillow
+  - seaborn
+  - patsy
+  - statsmodels
+  - networkx
+  - dask
+  - blaze
+  - odo
+  - altair
+  - tensorflow
+  - keras
+
+pip_packages:
+  - brewer2mpl
+  - ggplot
+  - ipythonblocks
+  - plotly
+
+cran_packages:
+  - car
+  - ggplot2
+  - XML
+  - plyr
+  - randomForest
+  - Hmisc
+  - stringr
+  - RColorBrewer
+  - reshape
+  - reshape2
+  - RCurl
+  - devtools
+  - dplyr
+  - httr
+  - knitr
+  - packrat
+  - rmarkdown
+  - rvtest
+  - testit
+  - testthat
+  - tidyr
+  - shiny
+  - base64enc
+  - Cairo
+  - codetools
+  - table
+  - gridExtra
+  - gtable
+  - hexbin
+  - jpeg
+  - Lahman
+  - MASS
+  - PKI
+  - png
+  - microbenchmark
+  - mgcv
+  - mapproj
+  - maps
+  - maptools
+  - mgcv
+  - multcomp
+  - nycflights13
+  - quantreg
+  - javareconf
+  - rJava
+  - roxygen2
+  - RSQLite
+  - lattice
+  - nlme
+  - RCurl 
+  - RHTMLForms
+  - RJSONIO
+  - RSelenium
+  - rgl
+  - caret
+  - data.table
+  - parallel
+  - testthat
+  - rpart
+  - caret
+  - RTextTools
+  - XLSX
+
+# ---------------------------------------------------
 # Optional settings
 # ---------------------------------------------------
 

--- a/roles/python/vars/main.yml
+++ b/roles/python/vars/main.yml
@@ -8,27 +8,3 @@ conda_config:
     - defaults
   show_channel_urls: yes
 
-conda_packages:
-  - numpy
-  - scipy
-  - matplotlib
-  - cython
-  - h5py
-  - scikit-learn
-  - scikit-image
-  - pandas
-  - sympy
-  - pillow
-  - seaborn
-  - patsy
-  - statsmodels
-  - networkx
-  - dask
-  - blaze
-  - odo
-pip_packages:
-  - brewer2mpl
-  - ggplot
-  - ipythonblocks
-  - plotly
-  

--- a/roles/r/tasks/main.yml
+++ b/roles/r/tasks/main.yml
@@ -19,9 +19,13 @@
   with_items:
     - repr
     - IRdisplay
-    - pbdZMQ
+    - evaluate
     - crayon
+    - pbdZMQ
     - devtools
+    - uuid
+    - digest
+    - stringi
 
 - name: install IRkernel
   command: R --quiet -e "if (! '{{item}}' %in% installed.packages()[,'Package']) devtools::install_github('IRkernel/{{item}}')"
@@ -33,8 +37,4 @@
 
 - name: install additional R packages
   command: R --quiet -e "if (! '{{item}}' %in% installed.packages()[,'Package']) install.packages('{{item}}', repos='http://cran.rstudio.com/')"
-  with_items:
-    - ggplot2
-    - dplyr
-    - reshape2
-    - car
+  with_items: '{{cran_packages}}'


### PR DESCRIPTION
This approach makes it a bit easier for users to customize the pip/conda/cran packages. It also expands the default list slightly. Will test on my deployment before merging...