### PR TITLE
Set Ansible to use Python 3 on the remote server

### DIFF
--- a/group_vars/jupyterhub_hosts
+++ b/group_vars/jupyterhub_hosts
@@ -8,9 +8,8 @@
 # Ansible
 # ---------------------------------------------------
 
-# Path of the Python 2.7 interpreter on the remote server
-# Note: Ansible requires Python 2.7 for provisioning so the path must be set
-ansible_python_interpreter: '/usr/bin/python2.7'
+# Path of the Python 3 interpreter on the remote server
+ansible_python_interpreter: '/usr/bin/python3'
 
 # ---------------------------------------------------
 # JupyterHub config directories


### PR DESCRIPTION
Installation of Python 2.7 was removed in https://github.com/jupyterhub/jupyterhub-deploy-teaching/pull/28, so we should use Python 3