### PR TITLE
use pip instead of pip3

### DIFF
--- a/roles/bash/tasks/main.yml
+++ b/roles/bash/tasks/main.yml
@@ -2,7 +2,7 @@
 # This playbook installs a bash environment and kernel
 
 - name: pip install bash_kernel package
-  pip: name={{item}} state=present editable=false
+  pip: name={{item}} state=present editable=false executable=pip
   become: true
   with_items:
       - bash_kernel

--- a/roles/cull_idle/tasks/main.yml
+++ b/roles/cull_idle/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: install cull_idle_servers dependencies
-  pip: name=python-dateutil state=present
+  pip: name=python-dateutil state=present executable=pip
 
 - name: install cull_idle_servers.py into {{jupyterhub_srv_dir}}
   copy: src=cull_idle_servers.py dest={{jupyterhub_srv_dir}} owner=root group=root mode=0700

--- a/roles/jupyterhub/tasks/packages.yml
+++ b/roles/jupyterhub/tasks/packages.yml
@@ -8,7 +8,7 @@
     - sqlalchemy
 
 - name: install jupyterhub via pip
-  pip: name={{item}} state=present editable=false
+  pip: name={{item}} state=present editable=false executable=pip
   become: true
   with_items:
     - jupyterhub==0.7

--- a/roles/nbgrader/tasks/main.yml
+++ b/roles/nbgrader/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: pip install nbgrader
-  pip: name={{item}} state=present
+  pip: name={{item}} state=present executable=pip
   become: true
   with_items:
     # - nbgrader

--- a/roles/python/tasks/python3.yml
+++ b/roles/python/tasks/python3.yml
@@ -6,6 +6,6 @@
   with_items: '{{conda_packages}}'
 
 - name: user pip packages
-  pip: name={{item}} state=present
+  pip: name={{item}} state=present executable=pip
   become: true
   with_items: '{{pip_packages}}'


### PR DESCRIPTION
deploying this today I noticed that installing `pip` packages fails with:

    failed: [*.compute.cloud.sdsc.edu] (item=brewer2mpl) => {"failed": true, "item": "brewer2mpl", "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}

the Ansible pip module tries to use `pip3` for python 3 but in Anaconda now the package is just named `pip`, so I explicitly configure it to use `pip` instead.