### PR TITLE
Explicitly call pip instead of pip3 for an Anaconda environment.

### DIFF
--- a/roles/python/tasks/python3.yml
+++ b/roles/python/tasks/python3.yml
@@ -6,6 +6,6 @@
   with_items: '{{conda_packages}}'
 
 - name: user pip packages
-  pip: name={{item}} state=present
+  pip: name={{item}} state=present executable=pip
   become: true
   with_items: '{{pip_packages}}'


### PR DESCRIPTION
When I deploy the Ansible playbook (deploy.yml), I encountered the following pip installation errors:

```
TASK [python : user pip packages] ******************************************************************************************************************************************
failed: [192.168.122.45.xip.io] (item=brewer2mpl) => {"failed": true, "item": "brewer2mpl", "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}
failed: [192.168.122.45.xip.io] (item=ggplot) => {"failed": true, "item": "ggplot", "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}
failed: [192.168.122.45.xip.io] (item=ipythonblocks) => {"failed": true, "item": "ipythonblocks", "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}
failed: [192.168.122.45.xip.io] (item=plotly) => {"failed": true, "item": "plotly", "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}`
```

As Anaconda/Miniconda is used as the Python environment, the correct pip3 executable is still named as pip (under /opt/conda/bin/pip). This fix aims to correct this issue. 

After specifying the executable option, I get the correct pip installation behaviour:

```
TASK [python : user pip packages] ******************************************************************************************************************************************
ok: [192.168.122.45.xip.io] => (item=brewer2mpl)
ok: [192.168.122.45.xip.io] => (item=ggplot)
ok: [192.168.122.45.xip.io] => (item=ipythonblocks)
ok: [192.168.122.45.xip.io] => (item=plotly)
```

Best Regards,
-najib
