### PR TITLE
fix letsencrypt-renew script

### DIFF
--- a/roles/nginx/files/letsencrypt-renew
+++ b/roles/nginx/files/letsencrypt-renew
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 date >> /var/log/letsencrypt.log
-certbot-auto renew --no-self-upgrade 2>&1 &>> /var/log/letsencrypt.log
-docker kill -s HUP nginx
+WEBROOT=/etc/letsencrypt/webroot
+test -d "$WEBROOT" || mkdir -p "$WEBROOT"
+certbot-auto renew --webroot --webroot-path="$WEBROOT" --no-self-upgrade 2>&1 &>> /var/log/letsencrypt.log
+service nginx reload


### PR DESCRIPTION
was copied from docker deployment, but not upgraded to deal with the fact that nginx is not run in docker

closes #79