### PR TITLE
Fix submodule docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ version = '1.0'
 release = '1.0'
 
 language = None
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'ansible-conda']
 pygments_style = 'sphinx'
 todo_include_todos = False
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,3 @@
-requirements_file: docs/requirements.txt
+requirements_file: ./docs/requirements.txt
 python:
     version: 3


### PR DESCRIPTION
RTD is finicky and stopped building after the latest submodule change. This PR should enable the docs to keep building even if there are future submodule changes.