### PR TITLE
Fix nbgrader installation and configure correctly for nbgrader>=0.5.0

### DIFF
--- a/roles/jupyterhub/templates/jupyterhub_config.py.j2
+++ b/roles/jupyterhub/templates/jupyterhub_config.py.j2
@@ -55,18 +55,6 @@ c.Authenticator.whitelist = set()
 {% endif %}
 
 c.JupyterHub.services = [
-{% if use_nbgrader %}
-{%- for course in nbgrader_courses %}
-    {
-        'name': 'formgrade-{{course.course_id}}',
-        'admin': True,
-        'url': 'http://127.0.0.1:{{course.port}}',
-#       'user': '{{course.owner}}',
-        'cwd': '{{home_dir}}/{{course.owner}}/nbgrader/{{course.course_id}}',
-        'command': ['nbgrader', 'formgrade']
-    },
-{% endfor -%}
-{% endif %}
 {% if use_cull_idle_servers %}
     {
         'name': 'cull_idle_servers',

--- a/roles/nbgrader/tasks/main.yml
+++ b/roles/nbgrader/tasks/main.yml
@@ -22,7 +22,7 @@
     - touch
 
 - name: make sure /srv/nbgrader/exchange exists
-  file: path={{nbgrader_exchange_dir}}/ state={{item}} owner=root group=root mode=0733
+  file: path={{nbgrader_exchange_dir}}/ state={{item}} owner=root group=root mode=0777
   become: true
   with_items:
     - directory
@@ -65,8 +65,14 @@
     - "{{nbgrader_courses}}"
     - ['source', 'release', 'feedback', 'autograded', 'submitted']
 
+- name: make sure .jupyter directory exists
+  file: path={{home_dir}}/{{item.owner}}/.jupyter/ state=directory owner={{item.owner}} group={{item.owner}} mode=0700
+  become: true
+  with_items:
+    - "{{nbgrader_courses}}"
+
 - name: install nbgrader config file
-  template: src=nbgrader_config.py.j2 dest={{home_dir}}/{{item.owner}}/nbgrader/{{item.course_id}}/nbgrader_config.py owner={{item.owner}} group={{item.owner}} mode=700
+  template: src=nbgrader_config.py.j2 dest={{home_dir}}/{{item.owner}}/.jupyter/nbgrader_config.py owner={{item.owner}} group={{item.owner}} mode=0700
   become: true
   with_items:
     - "{{nbgrader_courses}}"

--- a/roles/nbgrader/tasks/main.yml
+++ b/roles/nbgrader/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 
+- name: Make sure /opt/conda/src exists
+  file: path=/opt/conda/src/ state={{item}} owner=root group=root mode=0755
+  become: true
+  with_items:
+    - directory
+    - touch
+
 - name: pip install nbgrader
-  pip: name={{item}} state=present executable=pip
+  pip: name={{item}} state=present executable=pip extra_args="--src /opt/conda/src"
   become: true
   with_items:
     # - nbgrader

--- a/roles/nbgrader/templates/nbgrader_config.py.j2
+++ b/roles/nbgrader/templates/nbgrader_config.py.j2
@@ -1,10 +1,5 @@
+# {{ansible_managed}}
 # Configuration file for nbgrader.
-# Supervisord is responsible for logging.
 c = get_config()
-
-c.NbGrader.course_id = '{{item.course_id}}'
-
-c.FormgradeApp.authenticator_class = u'nbgrader.auth.hubauth.HubAuth'
-c.FormgradeApp.ip = '127.0.0.1'
-c.FormgradeApp.port = {{item.port}}
-c.HubAuth.grader_group = u'formgrade-{{item.course_id}}'
+c.CourseDirectory.root = '/home/{{item.owner}}/nbgrader/{{item.course_id}}'
+c.Exchange.course_id = '{{item.course_id}}'


### PR DESCRIPTION
This pull request fixes the following issues:

 * Currently, nbgrader is installed to `/tmp/src`, therefore it is lost and stops working if the server is rebooted.
 * The nbgrader role installs from git (master branch), however all the config files seem to be generated with version 0.4.0 in mind. Here we adopt the [new configuration scheme](http://nbgrader.readthedocs.io/en/stable/configuration/jupyterhub_config.html) for nbgrader>=0.5.0.

Please note that I'm a newcomer to jupyterhub, so I expect feedback --- this surely is not a well-polished patch. For example, I have no idea on how to get nbgrader working with multiple graders in this new configuration scheme.