### PR TITLE
Adding DockerSpawner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ target/
 customize.yml
 security/
 hosts
+
+# Ansible
+*.retry

--- a/deploy.yml
+++ b/deploy.yml
@@ -27,20 +27,22 @@
   roles:
     - common
     - python
+    - role: docker
+      when: use_dockerspawner is defined and use_dockerspawner
     - role: r
-      when: install_r_kernel is defined and install_r_kernel
+      when: install_r_kernel is defined and install_r_kernel and not use_dockerspawner
     - role: newrelic
       when: newrelic_license_key is defined and newrelic_license_key != ''
     - nginx
     - supervisor
     - saveusers
     - role: bash
-      when: install_bash_kernel is defined and install_bash_kernel
+      when: install_bash_kernel is defined and install_bash_kernel and not use_dockerspawner
     - jupyterhub
     - role: cull_idle
-      when: use_cull_idle_servers is defined and use_cull_idle_servers
+      when: use_cull_idle_servers is defined and use_cull_idle_servers and not use_dockerspawner
     - role: nbgrader
-      when: use_nbgrader is defined and use_nbgrader
+      when: use_nbgrader is defined and use_nbgrader and not use_dockerspawner
     - role: start_jupyterhub
   environment:
       PATH: "/opt/conda/bin:{{ default_path.stdout }}"

--- a/host_vars/hostname-docker.example
+++ b/host_vars/hostname-docker.example
@@ -60,9 +60,19 @@ cleanup_on_shutdown: true
 
 # Set to `true` to enable
 use_dockerspawner: true
+
+# The docker image to use
 docker_image: jupyterhub/singleuser:0.8
+
+# Add any additional docker admin users to this list
 docker_users: ['ubuntu']
-docker_spawner_class: dockerspawner.SystemUserSpawner
+
+# Specify the dockerspawner class to use
+# Valid options: [dockerspawner.DockerSpawner, dockerspawner.SystemUserSpawner]
+docker_spawner_class: dockerspawner.DockerSpawner
+
+# Memory Limit
+mem_limit: 500M
 
 # ------------------------------------------------------------------------------
 # Optional settings

--- a/host_vars/hostname-docker.example
+++ b/host_vars/hostname-docker.example
@@ -1,0 +1,156 @@
+---
+
+# An example `hostname` file
+#
+# Edit this file to customize settings for a particular host.
+# Save as FQDN of the hostname without the `.example` suffix,
+# such as `jupyterhub.myuniversity.edu`.
+
+# ------------------------------------------------------------------------------
+# Required settings
+# ------------------------------------------------------------------------------
+
+# The base directory of user accounts.
+home_dir: /home
+
+# Users with administrative privileges.
+jupyterhub_admin_users:
+  - instructor1
+  - instructor2
+
+# Whitelist of jupyterhub users.
+jupyterhub_users:
+  - instructor1
+  - instructor2
+  - grader1
+  - grader2
+  - student1
+  - student2
+
+# A list of jupyterhub groups to create, each with a list of members.
+jupyterhub_groups:
+  - {
+      name: group1,
+      members: ["instructor1", "grader1"]
+    }
+  - {
+      name: group2,
+      members: ["instructor2", "grader2"]
+    }
+
+# Whether to redirect users to JuptyerLab (/lab) by default
+jupyterlab_default: true
+
+# R kernel installation, set to true to enable.
+install_r_kernel: false
+
+# bash kernel installation, set to true to enable
+install_bash_kernel: true
+
+# Cleanup single user servers and the proxy on jupyterhub shutdown. Setting
+# this to false, will allow jupyterhub to be restarted while leaving the proxy
+# and single user servers running.
+cleanup_on_shutdown: true
+
+# ------------------------------------------------------------------------------
+# Docker
+# ------------------------------------------------------------------------------
+
+# TODO: Describe the usage of dockerspawner
+
+# Set to `true` to enable
+use_dockerspawner: true
+docker_image: jupyterhub/singleuser:0.8
+docker_users: ['ubuntu']
+docker_spawner_class: dockerspawner.SystemUserSpawner
+
+# ------------------------------------------------------------------------------
+# Optional settings
+# ------------------------------------------------------------------------------
+
+# The following sections are for optional features that can be enabled.
+
+# ------------------------------------------------------------------------------
+# OAuth
+# ------------------------------------------------------------------------------
+
+# The default authentication will use PAM, which is the standard UNIX password
+# standard. In the default configuration UNIX usernames and passwords will be
+# used for JupyterHub. Enabling OAuth through an OAuth provider (such as GitHub)
+# will enable users to log in using their username and passwords from the OAuth
+# provider. In this case, new users can be added using the JupyterHub Admin
+# page, and the users' home directories will be automatically created.
+
+# Set to `true` to enable.
+use_oauth: false
+
+# The OAuth callback URL.
+oauth_callback_url: https://mydomain.org/hub/oauth_callback
+
+# The OAuth client ID.
+oauth_client_id: ''
+
+# The OAuth client secret.
+oauth_client_secret: ''
+
+# ------------------------------------------------------------------------------
+# nbgrader
+# ------------------------------------------------------------------------------
+
+# nbgrader is a system for assigning, collecting and grading notebook based
+# homework assignments. For more details see:
+# http://nbgrader.readthedocs.io/en/stable/
+
+# Set to `true` to enable.
+use_nbgrader: false
+
+# ------------------------------------------------------------------------------
+# cull_idle_servers
+# ------------------------------------------------------------------------------
+
+# Set to `true` to enable.
+use_cull_idle_servers: false
+
+# The interval (in seconds) for checking for idle servers to cull.
+cull_every: 600
+
+# The idle timeout (in seconds).
+cull_timeout: 3600
+
+# ------------------------------------------------------------------------------
+# Misc optional settings
+# ------------------------------------------------------------------------------
+
+# List of the GitHub usernames who will receive root access via ssh. Public
+# GitHub SSH keys will be installed to allow the user to ssh into the server as
+# root.
+github_usernames: ['instructor1', 'grader1']
+
+# To mount local file systems populate this list. (Optional) This adds the
+# entries to /etc/fstab, creates the mount points, and mounts them. Note: Disks
+# must be partitioned and formatted.
+local_mounts: []
+#   - name: /mountpoint1
+#     src: /dev/sdb1
+#     fstype: ext3
+#   - name: /mountpoint2
+#     src: /dev/sdc1
+#     fstype: ext3
+
+# SSL using letsencrypt (optional - use letsencrypt default: false) If using
+# letsencrypt to generate SSL key/cert, set `use_letsencrypt` to `true`
+# Otherwise if not using letsencrypt for SSL, you MUST put your key and cert
+# into the security directory as `security/ssl.crt` and `security/ssl.key`.
+use_letsencrypt: false
+letsencrypt_email: ''
+
+# Should users have `/public_html/username` directories. Set this to `true` to
+# enable.
+nginx_public_html: false
+
+# Set Google Analytics Tracking ID (Optional).
+ga_tracking_id: ''
+
+# Set NewRelic license key (Optional).
+newrelic_license_key: ''
+

--- a/roles/docker/CHANGES.md
+++ b/roles/docker/CHANGES.md
@@ -1,0 +1,46 @@
+# Changelog
+
+### v0.2.0
+
+*Released: January 25th 2018*
+
+- Change version strategy to be separate from Docker releases (it was a bad idea!)
+- Change `docker_options` to `docker_daemon_options`
+- Default to Docker v18.01 on the CE edge channel
+- Fix systemd service so Docker loads after `network-online.target` instead of `network.target`
+- Add cron job to clean up after Docker
+- Add proper tests and support for Ubuntu 16, Debian Stretch and Debian Jessie
+- Update format and style consistencies
+
+### v17.12
+
+*Released: January 11th 2018*
+
+- Default to Docker v17.12 on the CE edge channel
+- Default to Docker Compose v1.18
+
+### v17.06
+
+*Released: June 28th 2017*
+
+- Default to Docker v17.06 on the CE edge channel
+- Default to Docker Compose v1.14
+- Update code base to support Docker's new version format
+
+### v0.1.2
+
+*Released: October 9th 2016*
+
+- Fix apt.cache https could not be found error
+
+### v0.1.1
+
+*Released: October 9th 2016*
+
+- Fix issue where `docker-engine` package was not found
+
+### v0.1.0
+
+*Released: October 8th 2016*
+
+- Initial release

--- a/roles/docker/LICENSE
+++ b/roles/docker/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Nick Janetakis nick.janetakis@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,0 +1,118 @@
+## What is ansible-docker? [![Build Status](https://secure.travis-ci.org/nickjj/ansible-docker.png)](http://travis-ci.org/nickjj/ansible-docker)
+
+It is an [Ansible](http://www.ansible.com/home) role to:
+
+- Install Docker (CE or EE)
+- Install Docker Compose
+- Configure the Docker daemon's options
+- Set up 1 or more users to run Docker without needing root access
+- Configure a cron job to run Docker clean up commands
+
+## Why would you want to use this role?
+
+If you're like me, you probably love Docker. This role provides everything you
+need to get going with a production ready Docker host.
+
+By the way, if you don't know what Docker is, or are looking to become an expert
+with it then check out
+[Dive into Docker: The Complete Docker Course for Developers](https://diveintodocker.com/?utm_source=ansibledocker&utm_medium=github&utm_campaign=readmetop).
+
+## Supported platforms
+
+- Ubuntu 16.04 LTS (Xenial)
+- Debian 8 (Jessie)
+- Debian 9 (Stretch)
+
+## Role variables
+
+```
+# Do you want to install Community Edition ('ce') or Enterprise Edition ('ee')?
+docker_edition: "ce"
+
+# Do you want to install Docker through the "stable" or "edge" channel?
+# Stable gets updated every quarter and Edge gets updated every month.
+docker_channel: "edge"
+
+# What version of Docker do you want to install?
+docker_version: "18.01.0"
+
+# Optionally install a specific version of Docker Compose.
+docker_install_docker_compose: True
+docker_compose_version: "1.18.0"
+
+# A list of users to be added to the Docker group. For example if you have a
+# user of 'deploy', then you'll want to set docker_users: ['deploy'] here.
+#
+# Keep in mind this user needs to already exist, it will not be created here.
+docker_users: []
+
+# A list of cron tasks to run. By default it will do a system prune every week
+# on Sunday at midnight. This will help keep your Docker hosts' disks under
+# control. 
+docker_cron_tasks:
+  - command: docker system prune -f
+    name: "Docker clean up"
+    # This uses the standard crontab syntax. 
+    schedule: ["0", "0", "*", "*", "0"]
+
+# Docker daemon options as they would appear on the command line, such as:
+# docker_daemon_options:
+#   - "--dns 8.8.8.8"
+docker_daemon_options: []
+
+# The APT GPG key id used to sign the Docker package.
+docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+
+# Address of the Docker repository.
+docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
+
+# How long should the apt-cache last in seconds?
+docker_apt_cache_time: 86400
+```
+
+## Example usage
+
+For the sake of this example let's assume you have a group called **app** and
+you have a typical `site.yml` file.
+
+To use this role edit your `site.yml` file to look something like this:
+
+```
+---
+
+- name: "Configure app server(s)"
+  hosts: "app"
+  become: True
+
+  roles:
+    - { role: "nickjj.docker", tags: "docker" }
+```
+
+Let's say you want to add a deploy user to the Docker group, you can do this by
+opening or creating `group_vars/app.yml` which is located relative to your
+`inventory` directory and then making it look like this:
+
+```
+---
+
+docker_users: ["deploy"]
+```
+
+*If you're looking for an Ansible role to create users, then check out my
+[user role](https://github.com/nickjj/ansible-user)*.
+
+Now you would run `ansible-playbook -i inventory/hosts site.yml -t iptables`.
+
+## Installation
+
+`$ ansible-galaxy install nickjj.docker`
+
+## Ansible Galaxy
+
+You can find it on the official
+[Ansible Galaxy](https://galaxy.ansible.com/nickjj/docker/) if you want to
+rate it.
+
+## License
+
+MIT

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+
+docker_edition: "ce"
+docker_channel: "edge"
+
+docker_version: "18.01.0"
+docker_install_docker_compose: True
+docker_compose_version: "1.18.0"
+
+docker_users: []
+
+docker_cron_tasks:
+  - job: docker system prune -f
+    name: "Docker clean up"
+    schedule: ["0", "0", "*", "*", "0"]
+
+docker_daemon_options: []
+
+docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
+
+docker_apt_cache_time: 86400

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Restart Docker
+  service:
+    name: "docker"
+    state: "restarted"

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,23 @@
+---
+
+galaxy_info:
+  author: "Nick Janetakis"
+  description: "Install and Docker and optionally Docker Compose."
+  company:
+  license: "license (MIT)"
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: "Ubuntu"
+      versions:
+        - "xenial"
+    - name: "Debian"
+      versions:
+        - "jessie"
+        - "stretch"
+
+  categories:
+    - "packaging"
+    - "system"
+
+dependencies: []

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+
+- name: Fail if Docker version is < 17.03
+  fail:
+    msg: "docker_version must be >= 17.03, yours is set to {{ docker_version }}."
+  when: docker_version | version_compare("17.03", "<")
+
+- name: Install Docker and role dependencies
+  apt:
+    name: "{{ item }}"
+    state: "present"
+    install_recommends: False
+  with_items:
+    - "apt-transport-https"
+    - "ca-certificates"
+    - "software-properties-common"
+    - "cron"
+
+- name: Get upstream APT GPG key
+  apt_key:
+    id: "{{ docker_apt_key }}"
+    keyserver: "{{ ansible_local.core.keyserver
+                   if (ansible_local|d() and ansible_local.core|d() and
+                       ansible_local.core.keyserver)
+                   else 'hkp://pool.sks-keyservers.net' }}"
+    state: "present"
+
+- name: Configure upstream APT repository
+  apt_repository:
+    repo: "{{ docker_repository }}"
+    state: "present"
+    update_cache: True
+
+- name: Install Docker
+  apt:
+    name: "docker-{{ docker_edition }}={{ docker_version }}~{{ docker_edition }}-0~{{ ansible_distribution | lower }}"
+    state: "present"
+    update_cache: True
+    install_recommends: False
+    cache_valid_time: "{{ docker_apt_cache_time }}"
+
+- name: Remove Upstart config file
+  file:
+    path: "/etc/default/docker"
+    state: "absent"
+
+- name: Ensure systemd directory exists
+  file:
+    path: "/etc/systemd/system"
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
+- name: Generate systemd unit file
+  template:
+    src: "etc/systemd/system/docker.service.j2"
+    dest: "/etc/systemd/system/docker.service"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  register: docker_register_systemd_service
+
+- name: Reload systemd daemon
+  command: "systemctl daemon-reload"
+  notify: ["Restart Docker"]
+  when: (docker_register_systemd_service and
+         docker_register_systemd_service | changed)
+
+- name: Add specific users to "docker" group
+  user:
+    name: "{{ item }}"
+    groups: "docker"
+    append: True
+  with_items: "{{ docker_users }}"
+  when: docker_users
+
+- name: Install Docker Compose
+  get_url:
+    url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64"
+    dest: "/usr/local/bin/docker-compose"
+    force: True
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  when: docker_install_docker_compose
+
+- name: Create cron tasks for Docker commands
+  cron:
+    name: "{{ item.name }}"
+    job: "{{ item.job }}"
+    minute: "{{ item.schedule[0] }}"
+    hour: "{{ item.schedule[1] }}"
+    day: "{{ item.schedule[2] }}"
+    month: "{{ item.schedule[3] }}"
+    weekday: "{{ item.schedule[4] }}"
+  with_items: "{{ docker_cron_tasks }}"
+  when: docker_cron_tasks

--- a/roles/docker/templates/etc/systemd/system/docker.service.j2
+++ b/roles/docker/templates/etc/systemd/system/docker.service.j2
@@ -1,0 +1,31 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd {{ docker_daemon_options | join(" ") }}
+ExecReload=/bin/kill -s HUP $MAINPID
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/docker/tests/test.yml
+++ b/roles/docker/tests/test.yml
@@ -1,0 +1,23 @@
+---
+
+- hosts: "all"
+
+  vars:
+    docker_daemon_options:
+      - "--dns 8.8.8.8"
+
+  roles:
+    - "role_under_test"
+
+  pre_tasks:
+    - name: Update APT cache
+      apt:
+        update_cache: True
+        cache_valid_time: 600
+
+  post_tasks:
+    - name: Ensure /etc/systemd/system/docker.service contains '--dns 8.8.8.8'
+      # Double dashes: https://unix.stackexchange.com/a/11382
+      shell: grep -- "--dns 8.8.8.8" /etc/systemd/system/docker.service
+      register: result
+      changed_when: result.rc != 0

--- a/roles/jupyterhub/tasks/packages.yml
+++ b/roles/jupyterhub/tasks/packages.yml
@@ -13,3 +13,5 @@
   with_items:
     - jupyterhub==0.8.1
     - oauthenticator==0.7.2
+    - dockerspawner==0.9.1
+    - jupyter_client==5.2.2

--- a/roles/jupyterhub/templates/jupyterhub_config.py.j2
+++ b/roles/jupyterhub/templates/jupyterhub_config.py.j2
@@ -15,6 +15,7 @@ c.JupyterHub.cleanup_servers = False
 {% if use_dockerspawner %}
 # spawn with Docker
 c.JupyterHub.spawner_class = '{{ docker_spawner_class }}'
+c.Spawner.mem_limit = '{{ mem_limit }}'
 
 # The docker instances need access to the Hub, so the default loopback port doesn't work:
 from jupyter_client.localinterfaces import public_ips

--- a/roles/jupyterhub/templates/jupyterhub_config.py.j2
+++ b/roles/jupyterhub/templates/jupyterhub_config.py.j2
@@ -12,9 +12,22 @@ c.JupyterHub.cleanup_proxy = False
 c.JupyterHub.cleanup_servers = False
 {% endif %}
 
+{% if use_dockerspawner %}
+# spawn with Docker
+c.JupyterHub.spawner_class = '{{ docker_spawner_class }}'
+
+# The docker instances need access to the Hub, so the default loopback port doesn't work:
+from jupyter_client.localinterfaces import public_ips
+c.JupyterHub.hub_ip = public_ips()[0]
+{% endif %}
+
+
 # Always start using the labhub script to make JupyterLab work,
 # but don't redirect users to it unless jupyterlab_default is set.
+{% if not use_dockerspawner %}
 c.Spawner.cmd = u'/usr/local/bin/start-jupyter-labhub.sh'
+{% endif %}
+
 {% if jupyterlab_default %}
 c.Spawner.default_url = '/lab'
 {% endif %}

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -72,6 +72,7 @@
 - name: find notebook static directory
   command: python3 -c 'import notebook; import os; print(os.path.join(notebook.__path__[0], "static"));'
   register: notebook_static_directory
+  when: not use_dockerspawner
 
 - name: install nginx.conf
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf owner=root group=root mode=0644 backup=yes

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -52,9 +52,11 @@ http {
         ssl_stapling_verify on;
         resolver_timeout 5s;
 
+{% if not use_dockerspawner %}
         location ~ /user/([a-zA-Z0-9\-_%]*)/static/(.*) {
             alias '{{ notebook_static_directory.stdout }}/$2';
         }
+{% endif %}
 
 {% if nginx_public_html %}
         location ~ ^/public_html/([a-zA-Z0-9\-_%]*)(/.*)?$ {

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -2,5 +2,8 @@
 
 - include_tasks: conda.yml
 - include_tasks: jupyter.yml
+  when: not use_dockerspawner
 - include_tasks: jupyterlab.yml
+  when: not use_dockerspawner
 - include_tasks: python3.yml
+  when: not use_dockerspawner

--- a/roles/start_jupyterhub/tasks/main.yml
+++ b/roles/start_jupyterhub/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: docker image pre-pull
+  command: docker pull {{ docker_image }}
+  when: use_dockerspawner
+
 - name: load jupyterhub supervisor config
   supervisorctl: name=jupyterhub state=present
 


### PR DESCRIPTION
This allows you to deploy a thin JupyterHub (in terms of packages) instance in favor "heavy" Docker images. These images allow for encapsulation of the environment (users could potentially be using different images with different packages) as well as limiting the resources a single container may consume. 